### PR TITLE
Correct dependency name in metadata

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library makes all the accessories of the NanoProtoShield accessab
 category=Other
 url=https://github.com/ZachEnglish/NanoProtoShield
 architectures=*
-depends=Adafruit BusIO, Adafruit Unified Sensor, Adafruit GFX Library, Adafruit SSD1306, Adafruit NeoPixel, Adafruit LED Backpack Library, OneWire, DallasTemperature, MPU6050_light, LiquidCrystal_I2C, PinChangeInterrupt
+depends=Adafruit BusIO, Adafruit Unified Sensor, Adafruit GFX Library, Adafruit SSD1306, Adafruit NeoPixel, Adafruit LED Backpack Library, OneWire, DallasTemperature, MPU6050_light, LiquidCrystal I2C, PinChangeInterrupt


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) specifies the dependencies that should be installed along with this library via Library Manager. This requires the use of the library name that is locked in when a library is submitted to Library Manager.

The "LiquidCrystal I2C" was named that way when it was added to Library Manager. Since then, [the library maintainer changed the name in that library's metadata](https://github.com/johnrickman/LiquidCrystal_I2C/commit/9a4e33e6cdaca805d70e220897d0b59446d52adf), but this does not affect the name in Library Manager (all the r[eleases made under the new name are rejected](https://github.com/johnrickman/LiquidCrystal_I2C/pull/50) by the indexer).